### PR TITLE
chore: loosen web3 pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
     -   id: check-yaml
 
@@ -16,7 +16,7 @@ repos:
         name: black
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
     -   id: flake8
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
     "lint": [
         "black>=22.3.0,<23.0",  # auto-formatter and linter
         "mypy>=0.950,<1.0",  # Static type analyzer
-        "flake8>=3.9.2,<4.0",  # Style linter
+        "flake8>=4.0.1,<5.0",  # Style linter
         "isort>=5.10.1,<6.0",  # Import sorting linter
     ],
     "release": [  # `release` GitHub Action job uses this
@@ -54,8 +54,8 @@ setup(
     url="https://github.com/ApeWorX/ape-alchemy",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.2.2,<0.3.0",
-        "web3>=5.25.0,<6.0.0",
+        "eth-ape>=0.2.7,<0.3.0",
+        "web3",  # Get web3 version from ape
         "importlib-metadata ; python_version<'3.8'",
     ],
     python_requires=">=3.7.2,<4",


### PR DESCRIPTION
### What I did

* Rely on ape for web3.py version pin to better adjust (and plan) for upgrades
* Other upgrades from template

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
