### PR TITLE
feat: get call tree implementation for ape 0.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.961
     hooks:
     -   id: mypy
         additional_dependencies: [types-PyYAML, types-requests]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,64 @@ To use the Alchemy provider plugin in most commands, set it via the `--network` 
 ape console --network ethereum:goerli:alchemy
 ```
 
+To connect to Alchemy from a Python script, use the `networks` top-level manager:
+
+```python
+from ape import networks
+
+with networks.parse_network_choice("ethereum:mainnet:alchemy") as provider:
+    ...
+```
+
+### Transaction Traces
+
+If you are using a paid tier of Alchemy, you have access to both Geth and Parity style traces.
+Parity traces are faster and thus are the ones uses in Ethereum receipts' `show_trace()` method:
+
+```python
+from ape import networks
+
+alchemy = networks.provider  # Assuming connected to Alchemy
+txn_hash = "0x053cba5c12172654d894f66d5670bab6215517a94189a9ffc09bc40a589ec04d"
+receipt = alchemy.get_transaction(txn_hash)
+receipt.show_trace()  # Prints the Transaction trace
+```
+
+To access the raw `CallTree`, do:
+
+```python
+from ape import networks
+
+alchemy = networks.provider  # Assuming connected to Alchemy
+txn_hash = "0x053cba5c12172654d894f66d5670bab6215517a94189a9ffc09bc40a589ec04d"
+call_tree = alchemy.get_call_tree(txn_hash)
+```
+
+To learn more about transaction traces, view [Ape's transaction guide](https://docs.apeworx.io/ape/stable/userguides/transactions.html#traces).
+
+**NOTE**: If you require the Geth style traces, you still have access to them via the `get_transaction_trace()` method and utilities from the `evm-trace` library:
+
+```python
+from evm_trace import CallType, get_calltree_from_geth_trace
+
+from ape import networks
+
+alchemy = networks.provider  # Assuming connected to Alchemy
+txn_hash = "0x053cba5c12172654d894f66d5670bab6215517a94189a9ffc09bc40a589ec04d"
+receipt = alchemy.get_transaction(txn_hash)
+root_node_kwargs = {
+    "gas_cost": receipt.gas_used,
+    "gas_limit": receipt.gas_limit,
+    "address": receipt.receiver,
+    "calldata": receipt.data,
+    "value": receipt.value,
+    "call_type": CallType.CALL,
+    "failed": receipt.failed,
+}
+trace_frame_iter = alchemy.get_transaction_trace(txn_hash)
+call_tree = get_calltree_from_geth_trace(trace_frame_iter)
+```
+
 ## Development
 
 Please see the [contributing guide](CONTRIBUTING.md) to learn more how to contribute to this project.

--- a/ape_alchemy/providers.py
+++ b/ape_alchemy/providers.py
@@ -80,9 +80,10 @@ class AlchemyEthereumProvider(Web3Provider, UpstreamProvider):
             yield TraceFrame(**frame)
 
     def get_call_tree(self, txn_hash: str) -> CallTreeNode:
+        receipt = self.get_transaction(txn_hash)
         raw_trace_list = self._make_request("trace_transaction", [txn_hash])
         trace_list = ParityTraceList.parse_obj(raw_trace_list)
-        return get_calltree_from_parity_trace(trace_list)
+        return get_calltree_from_parity_trace(trace_list, gas_cost=receipt.gas_used)
 
     def get_virtual_machine_error(self, exception: Exception) -> VirtualMachineError:
         if not hasattr(exception, "args") or not len(exception.args):

--- a/ape_alchemy/providers.py
+++ b/ape_alchemy/providers.py
@@ -22,7 +22,7 @@ class AlchemyProviderError(ProviderError):
 class AlchemyFeatureNotAvailable(AlchemyProviderError):
     """
     An error raised when trying to use a feature that is unavailable
-    on the user's tier.
+    on the user's tier or network.
     """
 
 

--- a/ape_alchemy/providers.py
+++ b/ape_alchemy/providers.py
@@ -1,8 +1,10 @@
 import os
-from typing import Dict
+from typing import Any, Dict, Iterator
 
 from ape.api import UpstreamProvider, Web3Provider
 from ape.exceptions import ContractLogicError, ProviderError, VirtualMachineError
+from evm_trace import CallTreeNode, ParityTraceList, TraceFrame, get_calltree_from_parity_trace
+from requests import HTTPError
 from web3 import HTTPProvider, Web3  # type: ignore
 from web3.exceptions import ContractLogicError as Web3ContractLogicError
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
@@ -14,6 +16,13 @@ _ENVIRONMENT_VARIABLE_NAMES = ("WEB3_ALCHEMY_PROJECT_ID", "WEB3_ALCHEMY_API_KEY"
 class AlchemyProviderError(ProviderError):
     """
     An error raised by the Alchemy provider plugin.
+    """
+
+
+class AlchemyFeatureNotAvailable(AlchemyProviderError):
+    """
+    An error raised when trying to use a feature that is unavailable
+    on the user's tier.
     """
 
 
@@ -63,7 +72,17 @@ class AlchemyEthereumProvider(Web3Provider, UpstreamProvider):
         self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
 
     def disconnect(self):
-        self._web3 = None  # type: ignore
+        self._web3 = None
+
+    def get_transaction_trace(self, txn_hash: str) -> Iterator[TraceFrame]:
+        frames = self._make_request("debug_traceTransaction", [txn_hash]).structLogs
+        for frame in frames:
+            yield TraceFrame(**frame)
+
+    def get_call_tree(self, txn_hash: str) -> CallTreeNode:
+        raw_trace_list = self._make_request("trace_transaction", [txn_hash])
+        trace_list = ParityTraceList.parse_obj(raw_trace_list)
+        return get_calltree_from_parity_trace(trace_list)
 
     def get_virtual_machine_error(self, exception: Exception) -> VirtualMachineError:
         if not hasattr(exception, "args") or not len(exception.args):
@@ -96,3 +115,24 @@ class AlchemyEthereumProvider(Web3Provider, UpstreamProvider):
                 return ContractLogicError()
 
         return VirtualMachineError(message=message)
+
+    def _make_request(self, rpc: str, args: list) -> Any:
+        try:
+            return self.web3.manager.request_blocking(rpc, args)  # type: ignore
+        except HTTPError as err:
+            response_data = err.response.json()
+            if "error" not in response_data:
+                raise AlchemyProviderError(str(err)) from err
+
+            error_data = response_data["error"]
+            message = (
+                error_data.get("message", str(error_data))
+                if isinstance(error_data, dict)
+                else error_data
+            )
+            cls = (
+                AlchemyFeatureNotAvailable
+                if "is not available" in message
+                else AlchemyProviderError
+            )
+            raise cls(message) from err

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ extras_require = {
     "lint": [
         "black>=22.3.0,<23.0",  # auto-formatter and linter
         "mypy>=0.961,<1.0",  # Static type analyzer
+        "types-requests",  # NOTE: Needed due to mypy typeshed
         "flake8>=4.0.1,<5.0",  # Style linter
         "isort>=5.10.1,<6.0",  # Import sorting linter
     ],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require = {
     ],
     "lint": [
         "black>=22.3.0,<23.0",  # auto-formatter and linter
-        "mypy>=0.950,<1.0",  # Static type analyzer
+        "mypy>=0.961,<1.0",  # Static type analyzer
         "flake8>=4.0.1,<5.0",  # Style linter
         "isort>=5.10.1,<6.0",  # Import sorting linter
     ],

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,10 @@ setup(
     url="https://github.com/ApeWorX/ape-alchemy",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.2.8,<0.3.0",
+        "eth-ape>=0.3.0,<0.4.0",
         "web3",  # Get web3 version from ape
         "importlib-metadata ; python_version<'3.8'",
+        "requests",
     ],
     python_requires=">=3.7.2,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

* Adds methods for getting call tree node using Parity traces as well as getting the raw Geth trace frames
* Creates custom exception handling around features not being available, either due to only being on the Free tier or being on network that does not have the feature.

### How I did it

* Implement the parity approach in `get_call_tree_node()` so traces default to the fast way in Receipts
* Provide the geth approach as a possibility (since Alchemy supports both!) via `get_transaction_trace()`.

### How to verify it

1. Connect to an Alchemy mainnet environment that has at least the middle tier subscription
2. Grab a txn hash from etherscan
3. Get the receipt via `provider.get_transaction(<hash>`
4. Run `receipt.show_trace()`

**NOTE**: required being on this branchhttps://github.com/ApeWorX/ape/pull/746

You can also test the feature by using `ape console --network ethereum:mainnet:alchemy` and doing:

```python
provider.get_call_tree(<txn_hash_from_etherscan>)
```

and only look at the raw `evm-trace` hash.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
