### PR TITLE
fix: remove broken testnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Quick Start
 
-[Alchemy](https://alchemy.com/?r=jk3NDM0MTIwODIzM) Provider plugin for Ethereum-based networks.
+Use the [Alchemy](https://alchemy.com/?r=jk3NDM0MTIwODIzM) provider plugin to interact with blockchains via APIs.
+The `ape-alchemy` plugin supports the following ecosystems:
+
+* Ethereum
+* Arbitrum
 
 ## Dependencies
 

--- a/ape_alchemy/__init__.py
+++ b/ape_alchemy/__init__.py
@@ -5,14 +5,11 @@ from .providers import AlchemyEthereumProvider
 NETWORKS = {
     "ethereum": [
         "mainnet",
-        "ropsten",
-        "rinkeby",
-        "kovan",
         "goerli",
     ],
     "arbitrum": [
         "mainnet",
-        "testnet",
+        "goerli",
     ],
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ FEATURE_NOT_AVAILABLE_BECAUSE_OF_TIER_RESPONSE = (
     "https://docs.alchemy.com/alchemy/documentation/apis"
 )
 FEATURE_NOT_AVAILABLE_BECAUSE_OF_NETWORK_RESPONSE = (
-    "trace_transaction is not available on the ETH_RINKEBY. "
+    "trace_transaction is not available on the ETH_GOERLI. "
     "For more information see our docs: "
     "https://docs.alchemy.com/alchemy/documentation/apis/ethereum"
 )
@@ -71,4 +71,4 @@ def feature_not_available_http_error(mocker, request):
 
 @pytest.fixture
 def alchemy_provider(networks) -> AlchemyEthereumProvider:
-    return networks.get_provider_from_choice("ethereum:rinkeby:alchemy")
+    return networks.ethereum.goerli.get_provider("alchemy")


### PR DESCRIPTION
### What I did

Rinkeby, kovan, and ropsten are bye bye.
This PR makes it good again.

### How I did it

Looked around and fixed stuff

### How to verify it

Will have to wait until https://github.com/ApeWorX/ape-arbitrum/pull/5 is released I think uhoh

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
