### PR TITLE
fix: handle pre-merge PoA blocks for Ethereum goerli

### DIFF
--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -73,8 +73,12 @@ class Alchemy(Web3Provider, UpstreamProvider):
     def connect(self):
         self._web3 = Web3(HTTPProvider(self.uri))
         try:
-            # optimism:mainnet, optimism:goerli, polygon:mainnet, or polygon:mumbai
-            if self._web3.eth.chain_id in (10, 420, 137, 80001):
+            # Any chain that *began* as PoA needs the middleware for pre-merge blocks
+            ethereum_goerli = 5
+            optimism = (10, 420)
+            polygon = (137, 80001)
+
+            if self._web3.eth.chain_id in (ethereum_goerli, *optimism, *polygon):
                 self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
             self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,4 +24,4 @@ def test_alchemy(ecosystem, network):
     with network_cls.use_provider("alchemy") as provider:
         assert isinstance(provider, Alchemy)
         assert provider.get_balance(ZERO_ADDRESS) > 0
-        assert provider.get_block("latest")
+        assert provider.get_block(0)


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #36 

### How I did it

Add middleware if 0th block needs it rather than latest.

### How to verify it

See  test.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
