### PR TITLE
fix: typo in env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ python3 setup.py install
 
 First, make sure you have one of the following environment variables set (it doesn't matter which one):
 
-* WEB3_ALCHEMY_PROJECT_ID
-* WEB3_ALCHEMY_API_KEY
-* WEB3_<ecosystem>_<network>_ALCHEMY_PROJECT_ID
-* WEB3_<ecosystem>_<network>_ALCHEMY_PROJECT_ID
+* `WEB3_ALCHEMY_PROJECT_ID`
+* `WEB3_ALCHEMY_API_KEY`
+* `WEB3_<ecosystem>_<network>_ALCHEMY_PROJECT_ID`
+* `WEB3_<ecosystem>_<network>_ALCHEMY_PROJECT_ID`
 
 For example, to use both Arbitrum and Ethereum in the same session, you could set both `WEB3_ARBITRUM_MAINNET_ALCHEMY_PROJECT_ID` and `WEB3_ETHEREUM_MAINNET_ALCHEMY_PROJECT_ID`.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ First, make sure you have one of the following environment variables set (it doe
 * WEB3_<ecosystem>_<network>_ALCHEMY_PROJECT_ID
 * WEB3_<ecosystem>_<network>_ALCHEMY_PROJECT_ID
 
-For example, to use both Arbitrum and Ethereum in the same session, you could set both `WEB3_ARBITRUM_MAINNET_ALCHEMY_PRPJECT_ID` and `WEB3_ETHEREUM_MAINNET_ALCHEMY_PRPJECT_ID`.
+For example, to use both Arbitrum and Ethereum in the same session, you could set both `WEB3_ARBITRUM_MAINNET_ALCHEMY_PROJECT_ID` and `WEB3_ETHEREUM_MAINNET_ALCHEMY_PROJECT_ID`.
 
 **NOTE**: If using non-Ethereum networks, take care to install the correct plugins, such as `ape-arbitrum`, `ape-optimism`, etc:
 


### PR DESCRIPTION
edit: markdown somehow drops the `<ecosystem>` and `<network>` part in `WEB3_<ecosystem>_<network>_ALCHEMY_PROJECT_ID` when not parsing as code notation.

fixes: https://github.com/ApeWorX/ape-alchemy/issues/39