### PR TITLE
feat: add support for `.http_uri` and `.ws_uri` in ProviderAPI v0.6.19

### DIFF
--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -84,6 +84,16 @@ class Alchemy(Web3Provider, UpstreamProvider):
         return uri
 
     @property
+    def http_uri(self) -> str:
+        # NOTE: Overriding `Web3Provider.http_uri` implementation
+        return self.uri
+
+    @property
+    def ws_uri(self) -> str:
+        # NOTE: Overriding `Web3Provider.ws_uri` implementation
+        return "ws" + self.uri[4:]  # Remove `http` in default URI w/ `ws`
+
+    @property
     def connection_str(self) -> str:
         return self.uri
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,6 +25,8 @@ def test_alchemy(ecosystem, network):
     ecosystem_cls = networks.get_ecosystem(ecosystem)
     network_cls = ecosystem_cls.get_network(network)
     with network_cls.use_provider("alchemy") as provider:
+        assert provider.http_uri.startswith("https")
+        assert provider.ws_uri.startswith("wss")
         assert isinstance(provider, Alchemy)
         assert provider.get_balance(ZERO_ADDRESS) > 0
         assert provider.get_block(0)


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
