### PR TITLE
feat: add sepolia networks

### DIFF
--- a/ape_alchemy/__init__.py
+++ b/ape_alchemy/__init__.py
@@ -11,14 +11,17 @@ NETWORKS = {
     "arbitrum": [
         "mainnet",
         "goerli",
+        "sepolia",
     ],
     "base": [
         "mainnet",
         "goerli",
+        "sepolia",
     ],
     "optimism": [
         "mainnet",
         "goerli",
+        "sepolia",
     ],
     "polygon": [
         "mainnet",


### PR DESCRIPTION
### What I did

Added sepolia networks for Optimism, Arbitrum, and Base

### How I did it

Added networks to the plugin `__init__.py` file

### How to verify it

Tested using `silverback` and specifying networks like `base:sepolia:alchemy`.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
