### PR TITLE
fix(devops): grant write perms to docs and drafter jobs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
     docs:
         runs-on: ubuntu-latest
+        permissions:
+          contents: write
 
         steps:
         - uses: actions/checkout@v3

--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
### What I did

Grants write perms to a couple of jobs that need it.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
