### PR TITLE
fix: remove sepolia from PoA conditional

### DIFF
--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -102,12 +102,11 @@ class Alchemy(Web3Provider, UpstreamProvider):
         self._web3 = Web3(HTTPProvider(self.uri))
         try:
             # Any chain that *began* as PoA needs the middleware for pre-merge blocks
-            ethereum_sepolia = 11155111
             base = 8453
             optimism = 10
             polygon = 137
 
-            if self._web3.eth.chain_id in (ethereum_sepolia, base, optimism, polygon):
+            if self._web3.eth.chain_id in (base, optimism, polygon):
                 self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
             self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)


### PR DESCRIPTION
### What I did

Sepolia is not a PoA network and should not receive the specific web3.py middleware.

Ref: #65

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
