### PR TITLE
fix: handle result from `make_request`

### DIFF
--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -184,7 +184,7 @@ class Alchemy(Web3Provider, UpstreamProvider):
     def make_request(self, rpc: str, parameters: Optional[Iterable] = None) -> Any:
         parameters = parameters or []
         try:
-            return self.web3.provider.make_request(RPCEndpoint(rpc), parameters)
+            result = self.web3.provider.make_request(RPCEndpoint(rpc), parameters)
         except HTTPError as err:
             response_data = err.response.json() if err.response else {}
             if "error" not in response_data:
@@ -202,6 +202,11 @@ class Alchemy(Web3Provider, UpstreamProvider):
                 else AlchemyProviderError
             )
             raise cls(message) from err
+
+        if isinstance(result, dict) and (res := result.get("result")):
+            return res
+
+        return result
 
     def send_private_transaction(self, txn: TransactionAPI, **kwargs) -> ReceiptAPI:
         """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -49,3 +49,18 @@ def test_polygon_zkevm():
         tx = provider.network.ecosystem.create_transaction(receiver=receiver)
         with pytest.raises(APINotImplementedError):
             _ = provider.create_access_list(tx)
+
+
+def test_make_requeset_handles_result():
+    """
+    There was a bug where eth_call because ape-alchemy wasn't
+    handling the result from make_request properly.
+    """
+    tx = {
+        "to": "0x5576815a38A3706f37bf815b261cCc7cCA77e975",
+        "value": "0x0",
+        "data": "0x70a082310000000000000000000000005576815a38a3706f37bf815b261ccc7cca77e975",
+    }
+    with networks.polygon_zkevm.cardona.use_provider("alchemy") as provider:
+        result = provider.make_request("eth_call", [tx, "latest"])
+        assert not isinstance(result, dict)


### PR DESCRIPTION
### What I did

I tried simply connecting to base sepolia using alchemy but I was able to make calls on contracts because it was trying to turn HexBytes(dict)

realized it was because ape-alchemy overrides make_request and does different stuff

### How I did it

### How to verify it

should get this know:

```
(ape08) ➜  chess.vy git:(main) ape console --network base:sepolia:alchemy

In [1]: contract = Contract("0x6fC96122dC615DeE5F988B0d03BBA50aEf5B8Ae2")

In [2]: account = accounts.load("metamask0")

In [3]: contract.knight_const()
Out[3]: 3
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
