### PR TITLE
perf: optimize trace return and revert values

### DIFF
--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -24,6 +24,7 @@ from web3.middleware import geth_poa_middleware
 from web3.types import RPCEndpoint
 
 from .exceptions import AlchemyFeatureNotAvailable, AlchemyProviderError, MissingProjectKeyError
+from .trace import AlchemyTransactionTrace
 
 # The user must either set one of these or an ENV VAR of the pattern:
 #  WEB3_<ECOSYSTEM>_<NETWORK>_PROJECT_ID or  WEB3_<ECOSYSTEM>_<NETWORK>_API_KEY
@@ -134,10 +135,7 @@ class Alchemy(Web3Provider, UpstreamProvider):
         )
 
     def get_transaction_trace(self, transaction_hash: str, **kwargs) -> TraceAPI:
-        if "debug_trace_transaction_parameters" not in kwargs:
-            kwargs["debug_trace_transaction_parameters"] = {}
-
-        return TransactionTrace(transaction_hash=transaction_hash, **kwargs)
+        return AlchemyTransactionTrace(transaction_hash=transaction_hash, **kwargs)
 
     def get_virtual_machine_error(self, exception: Exception, **kwargs) -> VirtualMachineError:
         txn = kwargs.get("txn")

--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -12,7 +12,6 @@ from ape.exceptions import (
 from ape.logging import logger
 from ape.types import BlockID
 from ape_ethereum.provider import Web3Provider
-from ape_ethereum.trace import TransactionTrace
 from ape_ethereum.transactions import AccessList
 from eth_pydantic_types import HexBytes
 from eth_typing import HexStr

--- a/ape_alchemy/trace.py
+++ b/ape_alchemy/trace.py
@@ -1,9 +1,8 @@
 from functools import cached_property
 from typing import Any, Optional
-from hexbytes import HexBytes
 
-from ape_ethereum.trace import TransactionTrace, TraceApproach
-from evm_trace import CallTreeNode
+from ape_ethereum.trace import TraceApproach, TransactionTrace
+from hexbytes import HexBytes
 
 
 class AlchemyTransactionTrace(TransactionTrace):

--- a/ape_alchemy/trace.py
+++ b/ape_alchemy/trace.py
@@ -1,0 +1,35 @@
+from functools import cached_property
+from typing import Any, Optional
+from hexbytes import HexBytes
+
+from ape_ethereum.trace import TransactionTrace, TraceApproach
+from evm_trace import CallTreeNode
+
+
+class AlchemyTransactionTrace(TransactionTrace):
+    call_trace_approach: TraceApproach = TraceApproach.PARITY
+
+    @cached_property
+    def return_value(self) -> Any:
+        node = self._top_level_call
+        if output := node.get("output"):
+            output_bytes = HexBytes(output)
+            if abi := self.root_method_abi:
+                return self._ecosystem.decode_returndata(abi, output_bytes)
+
+        return None
+
+    @cached_property
+    def revert_message(self) -> Optional[str]:
+        node = self._top_level_call
+        return node.get("revertReason")
+
+    @cached_property
+    def _top_level_call(self) -> dict:
+        return self.provider.make_request(
+            "debug_traceTransaction",
+            [
+                self.transaction_hash,
+                {"tracer": "callTracer", "tracerConfig": {"onlyTopLevelCall": True}},
+            ],
+        )

--- a/ape_alchemy/trace.py
+++ b/ape_alchemy/trace.py
@@ -16,6 +16,9 @@ class AlchemyTransactionTrace(TransactionTrace):
             if abi := self.root_method_abi:
                 return self._ecosystem.decode_returndata(abi, output_bytes)
 
+            # ABI is not known.
+            return output_bytes
+
         return None
 
     @cached_property

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,5 +1,6 @@
 import pytest
 from ape import chain, networks
+from ethpm_types import ContractType
 
 
 @pytest.fixture(autouse=True)
@@ -19,6 +20,19 @@ def test_revert_message():
 def test_return_value():
     txn_hash = "0xe0897d735b67893648b20085ecef16232733425329df844292d5b2774cca436b"
     receipt = chain.history[txn_hash]
+
+    # Ensure the ABI is cached so we can decode the return value.
+    abi = [
+        {
+            "type": "function",
+            "name": "submit",
+            "stateMutability": "payable",
+            "inputs": [{"name": "_referral", "type": "address"}],
+            "outputs": [{"name": "", "type": "uint256"}],
+        }
+    ]
+    chain.contracts[receipt.receiver] = ContractType(abi=abi)
+
     actual = receipt.return_value
     expected = 1244617160572980465
     assert actual == expected

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,24 @@
+import pytest
+from ape import chain, networks
+
+
+@pytest.fixture(autouse=True)
+def ethereum_mainnet_alchemy():
+    with networks.ethereum.mainnet.use_provider("alchemy"):
+        yield
+
+
+def test_revert_message():
+    txn_hash = "0x36144f609e0fc7afd3cc570d6a54582091642a44c5223a5ad59aa20008dd9577"
+    receipt = chain.history[txn_hash]
+    actual = receipt.trace.revert_message
+    expected = "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"
+    assert actual == expected
+
+
+def test_return_value():
+    txn_hash = "0xe0897d735b67893648b20085ecef16232733425329df844292d5b2774cca436b"
+    receipt = chain.history[txn_hash]
+    actual = receipt.return_value
+    expected = 1244617160572980465
+    assert actual == expected


### PR DESCRIPTION
### What I did

fixes: #80 
Fixes: APE-1799

Utilize the onlytopLevelcall config for ape-alchemy to make revert reason and return data grabbing much faster in ape-alchemy:

In [1]: txn_hash = "0x36144f609e0fc7afd3cc570d6a54582091642a44c5223a5ad59aa20008dd9577"
In [2]: receipt = chain.history[txn_hash]
In [3]: %time receipt.revert_message

Before: 1.52 s, 951 ms, 907 ms, 919 ms
After: 158 ms, 219 ms, 179 ms, 172 ms

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
