### PR TITLE
feat: add Fantom support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The `ape-alchemy` plugin supports the following ecosystems:
 - Optimism
 - Polygon
 - Polygon-ZkEVM
+- Fantom
 
 ## Dependencies
 

--- a/ape_alchemy/__init__.py
+++ b/ape_alchemy/__init__.py
@@ -27,6 +27,11 @@ NETWORKS = {
         "mainnet",
         "cardona",
     ],
+    "fantom": [
+        "opera",
+        "testnet",
+    ],
+
 }
 
 

--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -81,12 +81,12 @@ class Alchemy(Web3Provider, UpstreamProvider):
             "optimism": "https://opt-{0}.g.alchemy.com/v2/{1}",
             "polygon": "https://polygon-{0}.g.alchemy.com/v2/{1}",
             "polygon-zkevm": "https://polygonzkevm-{0}.g.alchemy.com/v2/{1}",
-            "fantom": "https://fantom-{0}.g.alchemy.com/v2/{1}"
+            "fantom": "https://fantom-{0}.g.alchemy.com/v2/{1}",
         }
 
         network_format = network_formats_by_ecosystem[ecosystem_name]
         network_name = self.network.name
-        if self.network.name == "opera":
+        if self.network.ecosystem.name == "fantom" and self.network.name == "opera":
             network_name = "opera-mainnet"
         uri = network_format.format(network_name, key)
         self.network_uris[(ecosystem_name, network_name)] = uri

--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -32,7 +32,7 @@ DEFAULT_ENVIRONMENT_VARIABLE_NAMES = ("WEB3_ALCHEMY_PROJECT_ID", "WEB3_ALCHEMY_A
 # Alchemy will try to publish private transactions for 25 blocks.
 PRIVATE_TX_BLOCK_WAIT = 25
 
-NETWORKS_SUPPORTING_WEBSOCKETS = ("ethereum", "arbitrum", "base", "optimism", "polygon")
+NETWORKS_SUPPORTING_WEBSOCKETS = ("ethereum", "arbitrum", "base", "optimism", "polygon", "fantom")
 
 
 class Alchemy(Web3Provider, UpstreamProvider):
@@ -81,10 +81,14 @@ class Alchemy(Web3Provider, UpstreamProvider):
             "optimism": "https://opt-{0}.g.alchemy.com/v2/{1}",
             "polygon": "https://polygon-{0}.g.alchemy.com/v2/{1}",
             "polygon-zkevm": "https://polygonzkevm-{0}.g.alchemy.com/v2/{1}",
+            "fantom": "https://fantom-{0}.g.alchemy.com/v2/{1}"
         }
 
         network_format = network_formats_by_ecosystem[ecosystem_name]
-        uri = network_format.format(self.network.name, key)
+        network_name = self.network.name
+        if self.network.name == "opera":
+            network_name = "opera-mainnet"
+        uri = network_format.format(network_name, key)
         self.network_uris[(ecosystem_name, network_name)] = uri
         return uri
 


### PR DESCRIPTION
Alchemy supports Fantom now

### What I did

Added support for Fantom mainnet and testnet

### How I did it

Added Fantom opera and testnet to the list of supported networks

Added Fantom url format strings

Added logic for replacing "opera" with "mainnet" when formatting the URL

### How to verify it

`ape console --network fantom:mainnet:alchemy`

### Checklist

- [X] Passes all linting checks (pre-commit and CI jobs)
- [X] New test cases have been added and are passing
- [X] Documentation has been updated
- [X] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
