### PR TITLE
fix: PoA detect and add amoy

### DIFF
--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -147,17 +147,17 @@ class Alchemy(Web3Provider, UpstreamProvider):
                 try:
                     block = self.web3.eth.get_block(option)  # type: ignore[arg-type]
                 except ExtraDataLengthError:
-                    is_likely_poa = True
+                    is_poa = True
                     break
                 else:
-                    is_likely_poa = (
+                    is_poa = (
                         "proofOfAuthorityData" in block
                         or len(block.get("extraData", "")) > MAX_EXTRADATA_LENGTH
                     )
-                    if is_likely_poa:
+                    if is_poa:
                         break
 
-            if is_likely_poa and ExtraDataToPOAMiddleware not in self.web3.middleware_onion:
+            if is_poa and ExtraDataToPOAMiddleware not in self.web3.middleware_onion:
                 self.web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
     def disconnect(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,6 +21,7 @@ def test_http(provider):
     assert provider.http_uri.startswith("https")
     assert provider.get_balance(ZERO_ADDRESS) > 0
     assert provider.get_block(0)
+    assert provider.get_block("latest")
 
 
 def test_ws(provider):


### PR DESCRIPTION
### What I did

Adds amoy to list of PoA middleware needing networks
Also makes the detection for PoA-needy dynamic (same as `ape-node`), so if we forget a different one, it will "still work".

fixes: https://github.com/ApeWorX/ape-polygon/issues/33

### How I did it

Add the chain ID
Handle ExtraDataLengthError

### How to verify it

```sh
ape console --network polygon:amoy:alchemy
```

then

```
provider.get_block("latest")
```

^ That fails on main branch.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
