### PR TITLE
fix: issue where empty results were not returned properly from `make_request()`

### DIFF
--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -303,10 +303,7 @@ class Alchemy(Web3Provider, UpstreamProvider):
             )
             raise cls(message) from err
 
-        if isinstance(result, dict) and (res := result.get("result")):
-            return res
-
-        return result
+        return result["result"] if isinstance(result, dict) and "result" in result else result
 
     def send_private_transaction(self, txn: TransactionAPI, **kwargs) -> ReceiptAPI:
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 max-line-length = 100
 ignore = E704,W503,PYD002,TC003,TC006
 exclude =
+	.venv*
 	venv*
 	docs
 	build

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -206,3 +206,14 @@ def test_make_request_rate_limiting(mocker, alchemy_provider, mock_web3):
     result = alchemy_provider.make_request("ape_testRateLimiting", parameters=[])
     assert rate_limit_tester.tries_made == rate_limit_tester.tries + 1
     assert result == {"success": True}
+
+
+def test_make_request_empty_result(alchemy_provider, mock_web3):
+    """
+    Testing the case when the result is empty that it still returns it
+    (and not the raw JSON response).
+    """
+    alchemy_provider._web3 = mock_web3
+    mock_web3.provider.make_request.return_value = {"jsonrpc": "2.0", "id": 8, "result": []}
+    result = alchemy_provider.make_request("ape_madeUpRPC", [])
+    assert result == []


### PR DESCRIPTION
### What I did

fixes: https://github.com/ApeWorX/ape/issues/2456
fixes: https://github.com/ApeWorX/ape/issues/2452

cursed walrus operator pwned us

### How I did it

return emptiness when be it

### How to verify it

demo that the user's reported issue is fixed:

```sh
ape console --network blast:mainnet:alchemy
```

```
In [1]: transfers = Contract("0xb1a5700fa2358173fe465e6ea4ff52e36e88e2ad").Transfer.range(0, chain.blocks[-1].number)

In [2]: list(transfers)
```

note: it does not fail anymore but the quest is so big that I am not going to actually wait for it to finish (searching entire blast chain for events?!) but before it failed right away and now it chugs along so we should be gucci

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
