### PR TITLE
fix: provider has random disconnects

### DIFF
--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -283,7 +283,7 @@ class Alchemy(Web3Provider, UpstreamProvider):
                 # NOTE: This is copied from `ape.utils.request_with_retry(..., is_rate_limit=None)`
                 (isinstance(err, HTTPError) and err.response.status_code == 429)
                 # NOTE: Sometimes Alchemy justs... stops responding in the middle of a response,
-                #       so treat it like a rate limit error since it usually works 2nd/3rd time around
+                #       so treat it like a rate limit error since it usually works 2nd/3rd time
                 or isinstance(err, (ConnectionError, ProtocolError))
             )
 

--- a/ape_alchemy/provider.py
+++ b/ape_alchemy/provider.py
@@ -274,18 +274,19 @@ class Alchemy(Web3Provider, UpstreamProvider):
 
         return super().create_access_list(transaction, block_id=block_id)
 
+    @staticmethod
+    def _response_checker(err: Exception) -> bool:
+        return (
+            # NOTE: This is copied from `ape.utils.request_with_retry(..., is_rate_limit=None)`
+            (isinstance(err, HTTPError) and err.response.status_code == 429)
+            # NOTE: Sometimes Alchemy justs... stops responding in the middle of a response,
+            #       so treat it like a rate limit error since it usually works 2nd/3rd time
+            or isinstance(err, (ConnectionError, ProtocolError))
+        )
+
     def make_request(self, rpc: str, parameters: Optional[Iterable] = None) -> Any:
         rate_limit = self.config.rate_limit
         parameters = parameters or []
-
-        def checker(err: Exception) -> bool:
-            return (
-                # NOTE: This is copied from `ape.utils.request_with_retry(..., is_rate_limit=None)`
-                (isinstance(err, HTTPError) and err.response.status_code == 429)
-                # NOTE: Sometimes Alchemy justs... stops responding in the middle of a response,
-                #       so treat it like a rate limit error since it usually works 2nd/3rd time
-                or isinstance(err, (ConnectionError, ProtocolError))
-            )
 
         try:
             result = request_with_retry(
@@ -295,7 +296,7 @@ class Alchemy(Web3Provider, UpstreamProvider):
                 max_retry_delay=rate_limit.max_retry_delay,
                 max_retries=rate_limit.max_retries,
                 retry_jitter=rate_limit.retry_jitter,
-                is_rate_limit=checker,
+                is_rate_limit=self._response_checker,
             )
         except HTTPError as err:
             response_data = err.response.json() if err.response else {}


### PR DESCRIPTION
### What I did

fixes: #98

Was getting really weird random disconnect errors w/ Alchemy in prod use, so needs a workaround

Example 1:
```py
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    response = self._make_request(
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 534, in _make_request
    response = conn.getresponse()
               ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connection.py", line 516, in getresponse
    httplib_response = super().getresponse()
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/http/client.py", line 1395, in getresponse
    response.begin()
  File "/usr/local/lib/python3.11/http/client.py", line 325, in begin
    version, status, reason = self._read_status()
                              ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/http/client.py", line 294, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
http.client.RemoteDisconnected: Remote end closed connection without response

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/requests/adapters.py", line 667, in send
    resp = conn.urlopen(
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 841, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/util/retry.py", line 474, in increment
    raise reraise(type(error), error, _stacktrace)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/util/util.py", line 38, in reraise
    raise value.with_traceback(tb)
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    response = self._make_request(
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 534, in _make_request
    response = conn.getresponse()
               ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connection.py", line 516, in getresponse
    httplib_response = super().getresponse()
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/http/client.py", line 1395, in getresponse
    response.begin()
  File "/usr/local/lib/python3.11/http/client.py", line 325, in begin
    version, status, reason = self._read_status()
                              ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/http/client.py", line 294, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
urllib3.exceptions.ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/ape_ethereum/provider.py", line 762, in _eth_call
    result = self.make_request("eth_call", arguments)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ape_alchemy/provider.py", line 280, in make_request
    result = request_with_retry(
             ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ape/utils/rpc.py", line 134, in request_with_retry
    return func()
           ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ape_alchemy/provider.py", line 281, in <lambda>
    lambda: self.web3.provider.make_request(RPCEndpoint(rpc), parameters),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/web3/_utils/caching/caching_utils.py", line 261, in wrapper
    return func(provider, method, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/web3/providers/rpc/rpc.py", line 169, in make_request
    raw_response = self._make_request(method, request_data)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/web3/providers/rpc/rpc.py", line 146, in _make_request
    return self._request_session_manager.make_post_request(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/web3/_utils/http_session_manager.py", line 145, in make_post_request
    with self.get_response_from_post_request(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/web3/_utils/http_session_manager.py", line 127, in get_response_from_post_request
    return session.post(endpoint_uri, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 637, in post
    return self.request("POST", url, data=data, json=json, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/adapters.py", line 682, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/taskiq/receiver/receiver.py", line 271, in run_task
    returned = await target_future
               ^^^^^^^^^^^^^^^^^^^
  File "/app/bot.py", line 40, in redeemed
    params=dict(amount=log.value // 10 ** stable.decimals()),
                                          ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ape/contracts/base.py", line 273, in __call__
    return ContractCall(
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ape/contracts/base.py", line 123, in __call__
    raw_output = self.provider.send_call(txn, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ape_ethereum/provider.py", line 708, in send_call
    return self._eth_call(arguments, raise_on_revert=raise_on_revert, skip_trace=skip_trace)
|            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ape_ethereum/provider.py", line 785, in _eth_call
    raise vm_err.with_ape_traceback() from err
ape.exceptions.VirtualMachineError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

I have another example but I want to check that this works first

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
